### PR TITLE
ci: dropping support for golang 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ '1.18', '1.19', '1.20', '1.21' ]
+        go-version: [ '1.19', '1.20', '1.21' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/opiproject/actions
 
-go 1.18
+go 1.19


### PR DESCRIPTION
usually 3 last version of golang is enough for backward

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
