### PR TITLE
fix(docker): pin docker compose version to 2.36.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3.0.0
-      
+
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3.0.0
@@ -82,6 +82,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3.0.0
+
+      - name: Install Docker Compose v2.36.0
+        run: |
+          mkdir -p ~/.docker/cli-plugins/
+          curl -SL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-$(uname -m) -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
+          docker compose version
 
       - name: Install additional kernel modules needed for OPI like VRF
         run: sudo apt-get install linux-modules-extra-$(uname -r)


### PR DESCRIPTION
The default version on ubuntu-latest is 2.36.2 and it refuses to build on "docker-compose up --build --force-recreate --detach opi-test" : https://github.com/opiproject/opi-mangoboost-bridge/actions/runs/15990307867/job/45267135701?pr=7