### PR TITLE
ci(deps): update golangci-lint dependencies

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.9'
-      - uses: golangci/golangci-lint-action@v6
+          go-version: '1.24.9'
+      - uses: golangci/golangci-lint-action@v8
         with:
           working-directory: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,6 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ['@commitlint/config-conventional']
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.63.4
+    rev: v2.5.0
     hooks:
     -   id: golangci-lint


### PR DESCRIPTION
Move to new versions of golangci lint.